### PR TITLE
feat: add toggle for production/development and client info fields

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,9 +16,7 @@
       "url": "https://support.vtex.com/hc/requests"
     },
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "scripts": {
     "prereleasy": "bash lint.sh"
@@ -64,6 +62,11 @@
         "description": "Token to performe calls to Glovo API",
         "type": "string"
       },
+      "production": {
+        "title": "Production environment",
+        "description": "Toggle between development and production environment",
+        "type": "boolean"
+      },
       "affiliateConfig": {
         "title": "Affiliate Settings",
         "description": "Affiliate ID and Glovo Store ID",
@@ -99,6 +102,42 @@
               "description": "Glovo Store ID registered in Glovo for the configured Affiliate ID",
               "type": "string"
             }
+          }
+        }
+      },
+      "clientProfileData": {
+        "title": "Client information",
+        "description": "Information about the client from Glovo",
+        "type": "object",
+        "required": ["email", "firstName", "lastName"],
+        "properties": {
+          "email": {
+            "title": "Email",
+            "type": "string"
+          },
+          "firstName": {
+            "title": "First name",
+            "type": "string"
+          },
+          "lastName": {
+            "title": "Last name",
+            "type": "string"
+          },
+          "documentType": {
+            "title": "Type of document",
+            "type": "string"
+          },
+          "document": {
+            "title": "Document",
+            "type": "string"
+          },
+          "phone": {
+            "title": "Phone number",
+            "type": "string"
+          },
+          "corporateName": {
+            "title": "Corporate name",
+            "type": "string"
           }
         }
       }

--- a/node/clients/glovo.ts
+++ b/node/clients/glovo.ts
@@ -19,9 +19,15 @@ export default class Glovo extends ExternalClient {
   }
 
   public updateProducts = async (ctx: Context, data: GlovoUpdateProduct) => {
-    const enviroment = this.context.production ? 'PRODUCTION' : 'STAGING'
     const { glovoStoreId, skuId, price, available } = data
-    const { glovoToken } = await Glovo.getAppSettings(ctx)
+    const {
+      glovoToken,
+      production,
+    }: { glovoToken: string; production: boolean } = await Glovo.getAppSettings(
+      ctx
+    )
+
+    const enviroment = production ? 'PRODUCTION' : 'STAGING'
 
     const payload: GlovoPatchProduct = {
       available,
@@ -44,9 +50,15 @@ export default class Glovo extends ExternalClient {
     ctx: StatusChangeContext,
     data: GlovoUpdateOrderStatus
   ) => {
-    const enviroment = this.context.production ? 'PRODUCTION' : 'STAGING'
     const { glovoStoreId, glovoOrderId, status } = data
-    const { glovoToken } = await Glovo.getAppSettings(ctx)
+    const {
+      glovoToken,
+      production,
+    }: { glovoToken: string; production: boolean } = await Glovo.getAppSettings(
+      ctx
+    )
+
+    const enviroment = production ? 'PRODUCTION' : 'STAGING'
 
     const payload: { status: string } = {
       status,
@@ -64,8 +76,15 @@ export default class Glovo extends ExternalClient {
   }
 
   public modifyOrder = async (ctx: any, data: GlovoModifyOrderPayload) => {
-    const enviroment = this.context.production ? 'PRODUCTION' : 'STAGING'
-    const { glovoToken } = await Glovo.getAppSettings(ctx)
+    const {
+      glovoToken,
+      production,
+    }: { glovoToken: string; production: boolean } = await Glovo.getAppSettings(
+      ctx
+    )
+
+    const enviroment = production ? 'PRODUCTION' : 'STAGING'
+
     const {
       storeId,
       glovoOrderId,

--- a/node/constants/index.ts
+++ b/node/constants/index.ts
@@ -1,9 +1,6 @@
 export const ORDERS = 'orders'
 
 /* eslint-disable @typescript-eslint/naming-convention */
-export const CUSTOMER_FIRST_NAME = 'Glovo'
-export const CUSTOMER_LAST_NAME = 'Customer'
-export const CLIENT_EMAIL = 'glovoapp@ametllerorigen.cat'
 export const RESIDENTIAL = 'Residential'
 export const HOME = 'Home'
 export const ESP = 'ESP'

--- a/node/index.ts
+++ b/node/index.ts
@@ -63,6 +63,7 @@ declare global {
     catalogUpdate: CatalogChange
     affiliateConfig: AffiliateInfo[]
     affiliateInfo: AffiliateInfo
+    clientProfileData: ClientProfileData
     orderSimulation: SimulationOrderForm
   }
 

--- a/node/middlewares/createOrder.ts
+++ b/node/middlewares/createOrder.ts
@@ -2,13 +2,17 @@ import { createVtexOrderData } from '../utils'
 
 export async function createOrder(ctx: Context, next: () => Promise<void>) {
   const {
-    state: { glovoOrder, orderSimulation, affiliateInfo },
+    state: { glovoOrder, orderSimulation, affiliateInfo, clientProfileData },
     clients: { orders },
   } = ctx
 
   const { salesChannel, affiliateId } = affiliateInfo
 
-  const vtexOrderData = createVtexOrderData(glovoOrder, orderSimulation)
+  const vtexOrderData = createVtexOrderData(
+    glovoOrder,
+    orderSimulation,
+    clientProfileData
+  )
 
   const vtexOrder = await orders.createOrder(
     vtexOrderData,

--- a/node/middlewares/validateSettings.ts
+++ b/node/middlewares/validateSettings.ts
@@ -16,6 +16,7 @@ export async function validateSettings(
 
   ctx.state.glovoToken = appConfig.glovoToken
   ctx.state.affiliateConfig = appConfig.affiliateConfig
+  ctx.state.clientProfileData = appConfig.clientProfileData
 
   await next()
 }

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -238,12 +238,12 @@ interface ClientProfileData {
   document: string | null
   phone: string | null
   corporateName: string | null
-  tradeName: string | null
-  corporateDocument: string | null
-  stateInscription: string | null
-  corporatePhone: string | null
-  isCorporate: boolean
-  userProfileId: string | null
+  tradeName?: string | null
+  corporateDocument?: string | null
+  stateInscription?: string | null
+  corporatePhone?: string | null
+  isCorporate?: boolean
+  userProfileId?: string | null
 }
 
 interface ShippingData {

--- a/node/utils.ts
+++ b/node/utils.ts
@@ -9,12 +9,9 @@ import {
   INVOICED,
   ACCEPTED,
   READY_FOR_PICKUP,
-  CLIENT_EMAIL,
   RESIDENTIAL,
   HOME,
   ESP,
-  CUSTOMER_FIRST_NAME,
-  CUSTOMER_LAST_NAME,
   START_HANDLING,
 } from './constants'
 
@@ -127,13 +124,20 @@ export const convertGlovoProductsToCompare = (
 
 export const createVtexOrderData = (
   glovoOrder: GlovoOrder,
-  orderSimulation: any
+  orderSimulation: any,
+  clientProfileData: ClientProfileData
 ): MarketplaceOrder => {
-  const { phone_number } = glovoOrder.customer
+  const { order_id, estimated_total_price } = glovoOrder
   const { items, pickupPoints, postalCode, logisticsInfo } = orderSimulation
-
-  const firstName = CUSTOMER_FIRST_NAME
-  const lastName = CUSTOMER_LAST_NAME
+  const {
+    email,
+    firstName,
+    lastName,
+    documentType,
+    document,
+    phone,
+    corporateName,
+  } = clientProfileData
 
   /** Re-Index items array */
   let counter = 0
@@ -179,18 +183,18 @@ export const createVtexOrderData = (
   )
 
   return {
-    marketplaceOrderId: glovoOrder.order_id,
+    marketplaceOrderId: order_id,
     marketplaceServicesEndpoint: 'https://api.glovoapp.com/',
-    marketplacePaymentValue: glovoOrder.estimated_total_price,
+    marketplacePaymentValue: estimated_total_price,
     items: updatedItems,
     clientProfileData: {
-      email: CLIENT_EMAIL,
+      email,
       firstName,
       lastName,
-      documentType: 'CIF',
-      document: 'B-67522904',
-      phone: phone_number || '9999999999',
-      corporateName: 'Glovoapp Groceries',
+      documentType,
+      document,
+      phone,
+      corporateName,
       tradeName: null,
       corporateDocument: null,
       stateInscription: null,
@@ -201,7 +205,7 @@ export const createVtexOrderData = (
     shippingData: {
       address: {
         addressType: RESIDENTIAL,
-        receiverName: `${CUSTOMER_FIRST_NAME} ${CUSTOMER_LAST_NAME}`,
+        receiverName: `${firstName} ${lastName}`,
         addressId: HOME,
         postalCode,
         city: pickupPoints[0].address.city,


### PR DESCRIPTION
#### What problem is this solving?

This PR adds multiple fields in the app settings. A **checkbox** to switch between production and development environments and **text input fields** to add the client profile information (email, first name, last name, documents, phone number and a corporate name) which is used to create the orders on VTEX.

#### App settings:
![Screenshot 2021-05-05 at 10 58 55](https://user-images.githubusercontent.com/17585823/117118494-1d65b500-ad91-11eb-9906-d5b6e196bd02.png)

