### PR TITLE
Fix/update glovo order status

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "glovo-integration",
   "vendor": "vtex",
-  "version": "3.0.0",
+  "version": "2.0.6",
   "title": "Glovo Integration",
   "description": "Glovo Integration",
   "dependencies": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "glovo-integration",
   "vendor": "vtex",
-  "version": "2.0.6",
+  "version": "3.0.4",
   "title": "Glovo Integration",
   "description": "Glovo Integration",
   "dependencies": {

--- a/node/events/compareOrder.ts
+++ b/node/events/compareOrder.ts
@@ -2,6 +2,7 @@
 import {
   convertGlovoProductsToCompare,
   getStoreInfoFromStoreId as getStoreInfoFromAffiliateId,
+  isValidAffiliateId,
 } from '../utils'
 import { CustomError } from '../utils/customError'
 
@@ -24,8 +25,7 @@ export async function compareOrder(
 
   const [orderIdAffiliate] = orderId.split('-')
 
-  // Filter orders that don't come form sellers (Example: 1234661638608-01)
-  if (Number(orderIdAffiliate)) {
+  if (!isValidAffiliateId(orderIdAffiliate)) {
     logger.warn({
       message: 'Received order without affiliateId',
       data: body,

--- a/node/events/compareOrder.ts
+++ b/node/events/compareOrder.ts
@@ -1,9 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {
-  convertGlovoProductsToCompare,
-  getStoreInfoFromStoreId as getStoreInfoFromAffiliateId,
-  isValidAffiliateId,
-} from '../utils'
+import { convertGlovoProductsToCompare, isValidAffiliateId } from '../utils'
 import { CustomError } from '../utils/customError'
 
 export async function compareOrder(
@@ -25,7 +21,7 @@ export async function compareOrder(
 
   const [orderIdAffiliate] = orderId.split('-')
 
-  if (!isValidAffiliateId(orderIdAffiliate)) {
+  if (!isValidAffiliateId(orderIdAffiliate, stores)) {
     logger.warn({
       message: 'Glovo order status not modified',
       reason: 'AffiliateId not valid',
@@ -36,16 +32,6 @@ export async function compareOrder(
   }
 
   try {
-    const storeInfo = getStoreInfoFromAffiliateId(orderIdAffiliate, stores)
-
-    if (!storeInfo) {
-      throw new CustomError({
-        message: `Store information not found for order modification for order ${orderId}`,
-        status: 500,
-        payload: { body },
-      })
-    }
-
     const order = await orders.getOrder(orderId)
     const orderRecord = await recordsManager.getOrderRecord(orderId)
 

--- a/node/events/compareOrder.ts
+++ b/node/events/compareOrder.ts
@@ -27,7 +27,8 @@ export async function compareOrder(
 
   if (!isValidAffiliateId(orderIdAffiliate)) {
     logger.warn({
-      message: 'Received order without affiliateId',
+      message: 'Glovo order status not modified',
+      reason: 'AffiliateId not valid',
       data: body,
     })
 

--- a/node/events/updateGlovoOrderStatus.ts
+++ b/node/events/updateGlovoOrderStatus.ts
@@ -24,7 +24,7 @@ export async function updateGlovoOrderStatus(ctx: StatusChangeContext) {
   const { orderId, currentState } = body
   const [orderIdAffiliate, glovoOrderId] = orderId.split('-')
 
-  if (!isValidAffiliateId(orderIdAffiliate)) {
+  if (!isValidAffiliateId(orderIdAffiliate, stores)) {
     logger.warn({
       message: 'Glovo order status not modified',
       reason: 'AffiliateId not valid',
@@ -34,16 +34,10 @@ export async function updateGlovoOrderStatus(ctx: StatusChangeContext) {
     return
   }
 
-  const storeInfo = getStoreInfoFromStoreId(orderIdAffiliate, stores)
-
-  if (!storeInfo) {
-    logger.warn({
-      message: `Store information not found for order modification for order ${orderId}`,
-      payload: body,
-    })
-
-    return
-  }
+  const storeInfo = getStoreInfoFromStoreId(
+    orderIdAffiliate,
+    stores
+  ) as StoreInfo
 
   const { glovoStoreId } = storeInfo
   const status = setGlovoStatus(currentState)

--- a/node/events/updateGlovoOrderStatus.ts
+++ b/node/events/updateGlovoOrderStatus.ts
@@ -22,9 +22,9 @@ export async function updateGlovoOrderStatus(ctx: StatusChangeContext) {
    * Check if the order comes from Glovo and remove the affiliateId (i.e. 'TST') from the VTEX orderId to get the glovoOrderId.
    */
   const { orderId, currentState } = body
-  const [affiliateId, glovoOrderId] = orderId.split('-')
+  const [orderIdAffiliate, glovoOrderId] = orderId.split('-')
 
-  if (!isValidAffiliateId(affiliateId)) {
+  if (!isValidAffiliateId(orderIdAffiliate)) {
     logger.warn({
       message: 'Glovo order status not modified',
       reason: 'AffiliateId not valid',
@@ -34,7 +34,7 @@ export async function updateGlovoOrderStatus(ctx: StatusChangeContext) {
     return
   }
 
-  const storeInfo = getStoreInfoFromStoreId(affiliateId, stores)
+  const storeInfo = getStoreInfoFromStoreId(orderIdAffiliate, stores)
 
   if (!storeInfo) {
     logger.warn({

--- a/node/events/updateGlovoOrderStatus.ts
+++ b/node/events/updateGlovoOrderStatus.ts
@@ -34,10 +34,7 @@ export async function updateGlovoOrderStatus(ctx: StatusChangeContext) {
     return
   }
 
-  const storeInfo = getStoreInfoFromStoreId(
-    orderIdAffiliate,
-    stores
-  ) as StoreInfo
+  const storeInfo = getStoreInfoFromStoreId(orderIdAffiliate, stores)
 
   const { glovoStoreId } = storeInfo
   const status = setGlovoStatus(currentState)

--- a/node/utils/utils.ts
+++ b/node/utils/utils.ts
@@ -89,3 +89,11 @@ export const convertGlovoProductsToCompare = (
 
   return items
 }
+
+export const isValidAffiliateId = (affiliateId: string) => {
+  if (Number(affiliateId)) {
+    return false
+  }
+
+  return true
+}

--- a/node/utils/utils.ts
+++ b/node/utils/utils.ts
@@ -96,13 +96,5 @@ export const isValidAffiliateId = (
     return false
   }
 
-  const storeIsConfigured = stores.some(
-    (store) => store.affiliateId === affiliateId
-  )
-
-  if (!storeIsConfigured) {
-    return false
-  }
-
-  return true
+  return stores.some((store) => store.affiliateId === affiliateId)
 }

--- a/node/utils/utils.ts
+++ b/node/utils/utils.ts
@@ -17,10 +17,8 @@ export const getStoreInfoFormGlovoStoreId = (
 ): StoreInfo | undefined =>
   stores.find(({ glovoStoreId }) => glovoStoreId === id)
 
-export const getStoreInfoFromStoreId = (
-  id: string,
-  stores: StoreInfo[]
-): StoreInfo | undefined => stores.find(({ affiliateId }) => affiliateId === id)
+export const getStoreInfoFromStoreId = (id: string, stores: StoreInfo[]) =>
+  stores.find(({ affiliateId }) => affiliateId === id) as StoreInfo
 
 export const convertGlovoProductToItems = (
   sellerId: string,
@@ -90,8 +88,19 @@ export const convertGlovoProductsToCompare = (
   return items
 }
 
-export const isValidAffiliateId = (affiliateId: string) => {
+export const isValidAffiliateId = (
+  affiliateId: string,
+  stores: StoreInfo[]
+): boolean => {
   if (Number(affiliateId)) {
+    return false
+  }
+
+  const storeIsConfigured = stores.some(
+    (store) => store.affiliateId === affiliateId
+  )
+
+  if (!storeIsConfigured) {
     return false
   }
 


### PR DESCRIPTION
### What problem is this solving?
The app was throwing errors when receiving orders not related to the integration (orders without an `affiliateId` or a different one from the ones configured in the settings).
We add a new utility function to check if the `affiliateId` is valid.


### How to test it
Checking the logs for the app on [Splunk](https://vtex.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dio_vtex_logs%20account%3Dametllerorigen%20workspace%3Dmaster%20app%3Dvtex.glovo-integration%403.0.0-beta.20%20level%3Dwarn%7C%20spath%20%22data.message%22%20%7C%20search%20%22data.message%22%3D%22Received%20order%20without%20affiliateId%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=%40d&latest=now&sid=1654165371.1896619_6FCAE5D3-4C94-42BE-80A2-A5ED7724692B), you should see logs with `level=warn` and `message='Received order without affiliateId'` (old message).