### PR TITLE
fix: bug with product update when receiving a Catalog Update

### DIFF
--- a/node/utils/glovo.ts
+++ b/node/utils/glovo.ts
@@ -179,7 +179,7 @@ export const updateGlovoProduct = async (
         }
 
         logger.info({
-          message: `Created new Menu Updates record for store ${storeName} with id ${id}`,
+          message: `Created new Menu Updates record for store ${storeName} with id ${glovoStoreId}`,
           data: storeMenuUpdates,
         })
       }

--- a/node/utils/glovo.ts
+++ b/node/utils/glovo.ts
@@ -30,7 +30,7 @@ export const updateGlovoProduct = async (
   catalogUpdate: CatalogChange
 ) => {
   const {
-    clients: { vbase, checkout, recordsManager },
+    clients: { vbase, recordsManager },
     vtex: { logger },
   } = ctx
 
@@ -80,7 +80,7 @@ export const updateGlovoProduct = async (
   for await (const store of stores) {
     const { id, storeName, glovoStoreId } = store
 
-    const simulation = await simulateItem(IdSku, store, checkout, logger)
+    const simulation = await simulateItem(IdSku, store, ctx)
 
     if (!simulation) {
       logger.warn({

--- a/node/utils/glovo.ts
+++ b/node/utils/glovo.ts
@@ -80,7 +80,7 @@ export const updateGlovoProduct = async (
   for await (const store of stores) {
     const { id, storeName, glovoStoreId } = store
 
-    const simulation = await simulateItem(IdSku, store, checkout)
+    const simulation = await simulateItem(IdSku, store, checkout, logger)
 
     if (!simulation) {
       logger.warn({

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -89,7 +89,7 @@ export const simulateItem = async (
   IdSku: string,
   store: StoreInfo,
   checkout: Checkout
-): Promise<SimulatedItem> => {
+): Promise<SimulatedItem | null> => {
   const { affiliateId, sellerId, salesChannel, postalCode, country } = store
   const simulationItem = createSimulationItem({
     id: IdSku,
@@ -105,25 +105,29 @@ export const simulateItem = async (
     country,
   })
 
-  const simulation = await checkout.simulation(...simulationPayload)
+  try {
+    const simulation = await checkout.simulation(...simulationPayload)
 
-  const {
-    items: [item],
-  } = simulation
+    const {
+      items: [item],
+    } = simulation
 
-  let itemInfo = {
-    price: 0,
-    available: false,
-  }
-
-  if (isSkuAvailable(item)) {
-    const { price, listPrice, unitMultiplier } = item
-
-    itemInfo = {
-      price: (Math.max(price, listPrice) * unitMultiplier) / 100,
-      available: true,
+    let itemInfo = {
+      price: 0,
+      available: false,
     }
-  }
 
-  return itemInfo
+    if (isSkuAvailable(item)) {
+      const { price, listPrice, unitMultiplier } = item
+
+      itemInfo = {
+        price: (Math.max(price, listPrice) * unitMultiplier) / 100,
+        available: true,
+      }
+    }
+
+    return itemInfo
+  } catch (error) {
+    return null
+  }
 }

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -89,9 +89,13 @@ export const createGlovoBulkUpdatePayload = (
 export const simulateItem = async (
   IdSku: string,
   store: StoreInfo,
-  checkout: Checkout,
-  logger: Logger
+  ctx: Context
 ): Promise<SimulatedItem | null> => {
+  const {
+    clients: { checkout },
+    vtex: { logger },
+  } = ctx
+
   const { affiliateId, sellerId, salesChannel, postalCode, country } = store
   const simulationItem = createSimulationItem({
     id: IdSku,

--- a/node/utils/simulation.ts
+++ b/node/utils/simulation.ts
@@ -1,3 +1,4 @@
+import type { Logger } from '@vtex/api'
 import type {
   Checkout,
   OrderFormItem,
@@ -88,7 +89,8 @@ export const createGlovoBulkUpdatePayload = (
 export const simulateItem = async (
   IdSku: string,
   store: StoreInfo,
-  checkout: Checkout
+  checkout: Checkout,
+  logger: Logger
 ): Promise<SimulatedItem | null> => {
   const { affiliateId, sellerId, salesChannel, postalCode, country } = store
   const simulationItem = createSimulationItem({
@@ -128,6 +130,12 @@ export const simulateItem = async (
 
     return itemInfo
   } catch (error) {
+    logger.warn({
+      message:
+        error.message ?? `Simulation for product with skuId ${IdSku} failed`,
+      data: error,
+    })
+
     return null
   }
 }


### PR DESCRIPTION
### What problem is this solving?
To keep the Glovo stores catalogs updated we keep a record of the latest state of every product on the global menu for each one of the stores.
In order to do this, every time we receive a `Catalog Update` from VTEX we run a simulation of the product for each store and check if the product record exists and if the state has changed.

Sometimes the simulation would fail and stop the whole process for all stores due to no error handling in the utility function where the process was defined (`/node/utils/simulation.ts --> simulateItem function`) . This sometimes created a mismatch between the prices and availability of a product between a client's and Glovo's catalog.

With this PR we handle the error so that in case the simulation fails, the process does not stop and continues for all stores.

### How to test it?
The app is linked in this workspace.

To test you can follow these steps:
1. Make a change in the [inventory](https://glvcatalogupdate--ametllerorigenqa.myvtex.com/admin/inventory/?keyword=&page=1&perPage=10&warehouseIds=1cdf9c0). You can use product with skuId 100 (aranja rosa).
2. Open Splunk and do a new search with this query:
```
index=io_vtex_logs account=ametllerorigenqa workspace=glvcatalogupdate app="vtex.glovo-integration@3.0.0" data.message="Product with sku * for store * already up to date"
```

You should see one of either these messages for every store configured in the settings (this workspace has 8 stores): 
- Product with sku `{{IdSku}}` from store `{{glovoStoreId}}` has been updated.
- Product with sku `{{IdSku}}` for store `{{glovoStoreId}}` already up to date.


_Reminder: the build check fails die to the GraphQL schema published on v2_