### PR TITLE
fix: add lastName backup value to avoid order creation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add backup value for first and last names to avoid errors (`ORD007`) when creating orders.
+
 ## [3.4.0] - 2023-03-03
 
 ## [3.3.1] - 2023-03-03

--- a/node/utils/orders.ts
+++ b/node/utils/orders.ts
@@ -90,8 +90,8 @@ export const createVtexOrderData = (
     savePersonalData: false,
     clientProfileData: {
       email: getEmail(customerName, phone_number, email),
-      firstName: getFirstName(customerName),
-      lastName: getLastName(customerName),
+      firstName: getFirstName(customerName) ?? firstName,
+      lastName: getLastName(customerName) ?? lastName,
       documentType,
       document,
       phone: phone_number ?? phone,


### PR DESCRIPTION
#### What problem is this solving?
Glovo allows clients to use only their first name and does not enforce last name. VTEX needs a last name to create the order.
With this PR we add a backup value (the one defined on the settings) to avoid this.
