### PR TITLE
fix: Glovo order modification payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Bug affecting removed items in Glovo order modifications.
+
 ## [3.5.1] - 2023-04-14
 
 ### Fixed

--- a/node/typings/glovo.d.ts
+++ b/node/typings/glovo.d.ts
@@ -180,12 +180,12 @@ interface GlovoUpdateOrderStatus {
 interface GlovoModifyOrderPayload {
   glovoStoreId: string
   glovoOrderId: string
-  replacements: GlovoModifyReplacements[]
+  replacements: GlovoModifyReplacement[]
   removed_purchases: Array<string | undefined>
   added_products: GlovoModifiedProduct[]
 }
 
-interface GlovoModifyReplacements {
+interface GlovoModifyReplacement {
   purchased_product_id: string
   product: GlovoModifiedProduct
 }

--- a/node/utils/orders.ts
+++ b/node/utils/orders.ts
@@ -181,3 +181,33 @@ function getLastName(name: string) {
 function getReceiverName(name: string, phone_number: string) {
   return `${name} - ${phone_number}`
 }
+
+/**
+ * Function to get the items that were changed in an order
+ *
+ * @param changesData Order modification event changesAttachements
+ * @returns changedItems Object with the items that were changed { itemId: { quantity: number } }
+ */
+export function getChangedItems(changesData: ChangesData[]) {
+  const changedItems: Record<string, { quantity: number }> = {}
+
+  for (const change of changesData) {
+    for (const item of change.itemsAdded) {
+      if (!changedItems[item.id]) {
+        changedItems[item.id] = { quantity: item.quantity }
+      } else {
+        changedItems[item.id].quantity += item.quantity
+      }
+    }
+
+    for (const item of change.itemsRemoved) {
+      if (!changedItems[item.id]) {
+        changedItems[item.id] = { quantity: -item.quantity }
+      } else {
+        changedItems[item.id].quantity -= item.quantity
+      }
+    }
+  }
+
+  return changedItems
+}


### PR DESCRIPTION
#### What problem is this solving?
The Glovo order modification had an issue when removing products from the original order. The products were being completely removed even if the modification was just to lower the quantity.
The new flow makes use of the `replacements` array as specified in [Glovo's documentation](https://api-docs.glovoapp.com/partners/index.html#operation/Modify-order-products).

#### How to test it?
This was tested with the help of the CX team.

#### Screenshots or example usage:
![Screenshot 2023-04-17 at 18 39 52](https://user-images.githubusercontent.com/17585823/232553069-f8f980ec-9932-462e-a67f-6215c826efd2.jpg)
